### PR TITLE
Update conf.go

### DIFF
--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -15,7 +15,7 @@ const (
 	DefaultStorageDir     = "/var/lib/machines"
 	DefaultUnitFilePath   = "/etc/systemd/system"
 	DefaultGPGDir         = "/etc/pki/rpm-gpg"
-	DefaultPackages       = "systemd,dbus,iproute2,tdnf,photon-release,photon-repos,curl,shadow,ncurses-terminfo"
+	DefaultPackages       = "systemd,dbus,iproute2,tdnf,photon-release,photon-repos,curl,shadow,ncurses-terminfoiputils,glibc,zlib,filesystem,pkg-config,bash,bzip2,procps-ng,iana-etc,coreutils,bc,libtool,net-tools,findutils,xz,util-linux,kmod,linux-esx,ca-certificates,iptables,Linux-PAM,file,e2fsprogs,rpm,openssh,gdbm,python3,python3-libs,python3-xml,sed,grep,cpio,gzip,vim,open-vm-tools,docker,bridge-utils,cloud-init,krb5,which,tzdata,initramfs"
 
 	DefaultParentLink  = "eth0"
 	DefaultNetworkKind = "link"


### PR DESCRIPTION
Add default packages to photon container to make it similar to
photon minimal ova. This helps to run package tests without any
modifications in the test files.